### PR TITLE
Implement reverse ID to URL index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Saves reverse index, from id to url and saves redirect in case of change in route
 
 ## [0.7.1] - 2020-02-11
 ### Fixed

--- a/node/clients/rewriterGraphql.ts
+++ b/node/clients/rewriterGraphql.ts
@@ -108,7 +108,7 @@ export class RewriterGraphql extends AppGraphQLClient {
             'x-vtex-locale': locale,
             'x-vtex-tenant': tenant,
           },
-          metric: 'rewriter-save-internal',
+          metric: 'rewriter-get-internal',
         }
       )
       .then(res => res.data)

--- a/node/clients/rewriterGraphql.ts
+++ b/node/clients/rewriterGraphql.ts
@@ -1,16 +1,32 @@
 import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
-import { InternalInput } from 'vtex.rewriter'
+import { Internal, InternalInput, RedirectInput } from 'vtex.rewriter'
 
-const rewiterSaveManyInternalMutation = `mutation SaveMany($routes: [InternalInput!]!) {
+const rewriterSaveManyInternalMutation = `mutation SaveMany($routes: [InternalInput!]!) {
   internal {
     saveMany(routes: $routes)
   }
 }`
 
-const rewiterSaveInternalMutation = `mutation Save($route: InternalInput!) {
+const rewriterSaveInternalMutation = `mutation Save($route: InternalInput!) {
   internal {
     save(route: $route) {
       type
+    }
+  }
+}`
+
+const rewriterSaveRedirectMutation = `mutation Save($route: RedirectInput!) {
+  redirect {
+    save(route: $route) {
+      type
+    }
+  }
+}`
+
+const rewriterGetInternal = `query Internal($path: String!) {
+  internal {
+    get(path: $path) {
+      id
     }
   }
 }`
@@ -20,11 +36,11 @@ export class RewriterGraphql extends AppGraphQLClient {
     super('vtex.rewriter@1.x', ctx, opts)
   }
 
-  public async saveManyInternals(internals: InternalInput[]){
+  public async saveManyInternals(internals: InternalInput[]) {
     const { tenant, locale } = this.context
     this.graphql.mutate<boolean, { routes: InternalInput[] }>(
       {
-        mutate: rewiterSaveManyInternalMutation,
+        mutate: rewriterSaveManyInternalMutation,
         variables: { routes: internals },
       },
       {
@@ -39,11 +55,11 @@ export class RewriterGraphql extends AppGraphQLClient {
     )
   }
 
-  public async saveInternal(internal: InternalInput){
+  public async saveInternal(internal: InternalInput) {
     const { tenant, locale } = this.context
     this.graphql.mutate<boolean, { route: InternalInput }>(
       {
-        mutate: rewiterSaveInternalMutation,
+        mutate: rewriterSaveInternalMutation,
         variables: { route: internal },
       },
       {
@@ -56,5 +72,45 @@ export class RewriterGraphql extends AppGraphQLClient {
         metric: 'rewriter-save-internal',
       }
     )
+  }
+
+  public async saveRedirect(redirect: RedirectInput) {
+    const { tenant, locale } = this.context
+    this.graphql.mutate<boolean, { route: RedirectInput }>(
+      {
+        mutate: rewriterSaveRedirectMutation,
+        variables: { route: redirect },
+      },
+      {
+        headers: {
+          ...(this.options && this.options.headers),
+          'Proxy-Authorization': this.context.authToken,
+          'x-vtex-locale': locale,
+          'x-vtex-tenant': tenant,
+        },
+        metric: 'rewriter-save-redirect',
+      }
+    )
+  }
+
+  public async getInternal(path: string) {
+    const { tenant, locale } = this.context
+    return this.graphql
+      .query<Internal, { path: string }>(
+        {
+          query: rewriterGetInternal,
+          variables: { path },
+        },
+        {
+          headers: {
+            ...(this.options && this.options.headers),
+            'Proxy-Authorization': this.context.authToken,
+            'x-vtex-locale': locale,
+            'x-vtex-tenant': tenant,
+          },
+          metric: 'rewriter-save-internal',
+        }
+      )
+      .then(res => res.data)
   }
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -14,6 +14,7 @@ import {
   unwrapProductTranslatables,
   unwrapSkuTranslatables,
 } from './events/unwrap'
+import { initialize } from './middlewares/initialize'
 import { saveInternalBrandRoute } from './middlewares/internals/saveInternalBrandRoute'
 import { saveInternalCategoryRoute } from './middlewares/internals/saveInternalCategoryRoute'
 import { saveInternalProductRoute } from './middlewares/internals/saveInternalProductRoute'
@@ -69,6 +70,7 @@ export default new Service<Clients, State, ParamsContext>({
   events: {
     broadcasterBrand: [
       throttle,
+      initialize,
       tenant,
       saveInternalBrandRoute,
       unwrapBrandTranslatables,
@@ -76,6 +78,7 @@ export default new Service<Clients, State, ParamsContext>({
     ],
     broadcasterCategory: [
       throttle,
+      initialize,
       tenant,
       saveInternalCategoryRoute,
       unwrapCategoryTranslatables,
@@ -83,6 +86,7 @@ export default new Service<Clients, State, ParamsContext>({
     ],
     broadcasterProduct: [
       throttle,
+      initialize,
       tenant,
       saveInternalProductRoute,
       unwrapProductTranslatables,

--- a/node/middlewares/initialize.ts
+++ b/node/middlewares/initialize.ts
@@ -1,0 +1,9 @@
+import { Resources } from '../resources'
+import { ColossusEventContext } from '../typings/Colossus'
+
+
+export async function initialize(ctx: ColossusEventContext, next: () => Promise<any>) {
+  ctx.resources = new Resources(ctx)
+
+  await next()
+}

--- a/node/middlewares/initialize.ts
+++ b/node/middlewares/initialize.ts
@@ -1,8 +1,10 @@
 import { Resources } from '../resources'
 import { ColossusEventContext } from '../typings/Colossus'
 
-
-export async function initialize(ctx: ColossusEventContext, next: () => Promise<any>) {
+export async function initialize(
+  ctx: ColossusEventContext,
+  next: () => Promise<any>
+) {
   ctx.resources = new Resources(ctx)
 
   await next()

--- a/node/middlewares/initialize.ts
+++ b/node/middlewares/initialize.ts
@@ -5,7 +5,7 @@ export async function initialize(
   ctx: ColossusEventContext,
   next: () => Promise<any>
 ) {
-  ctx.resources = new Resources(ctx)
+  ctx.state.resources = new Resources(ctx)
 
   await next()
 }

--- a/node/middlewares/internals/saveInternalBrandRoute.ts
+++ b/node/middlewares/internals/saveInternalBrandRoute.ts
@@ -20,6 +20,7 @@ export async function saveInternalBrandRoute(
 ) {
   const {
     clients: { apps, rewriterGraphql },
+    resources: { idUrlIndex },
     vtex: { logger },
   } = ctx
   try {
@@ -29,7 +30,10 @@ export async function saveInternalBrandRoute(
 
     const internal: InternalInput = getBrandInternal(path, brand.id)
 
-    await rewriterGraphql.saveInternal(internal)
+    await Promise.all([
+      rewriterGraphql.saveInternal(internal),
+      idUrlIndex.save(brand.id, path),
+    ])
   } catch (error) {
     logger.error(error)
   }

--- a/node/middlewares/internals/saveInternalBrandRoute.ts
+++ b/node/middlewares/internals/saveInternalBrandRoute.ts
@@ -20,7 +20,9 @@ export async function saveInternalBrandRoute(
 ) {
   const {
     clients: { apps, rewriterGraphql },
-    resources: { idUrlIndex },
+    state: {
+      resources: { idUrlIndex },
+    },
     vtex: { logger },
   } = ctx
   try {

--- a/node/middlewares/internals/saveInternalCategoryRoute.ts
+++ b/node/middlewares/internals/saveInternalCategoryRoute.ts
@@ -39,7 +39,9 @@ const saveCategoriesInternal = async (
 ) => {
   const {
     clients: { rewriterGraphql, apps },
-    resources: { idUrlIndex },
+    state: {
+      resources: { idUrlIndex },
+    },
   } = ctx
   const internals = await Promise.all(
     identifiedCategories.map(async identifiedCategory => {

--- a/node/middlewares/internals/saveInternalProductRoute.ts
+++ b/node/middlewares/internals/saveInternalProductRoute.ts
@@ -29,6 +29,7 @@ export async function saveInternalProductRoute(
 ) {
   const {
     clients: { apps, rewriterGraphql },
+    resources: { idUrlIndex },
     vtex: { logger },
   } = ctx
   try {
@@ -41,7 +42,10 @@ export async function saveInternalProductRoute(
       ? getProductInternal(path, product.id, bindings)
       : getProductNotFoundInternal(path)
 
-    await rewriterGraphql.saveInternal(internal)
+    await Promise.all([
+      rewriterGraphql.saveInternal(internal),
+      idUrlIndex.save(product.id, bindings, path),
+    ])
   } catch (error) {
     logger.error(error)
   }

--- a/node/middlewares/internals/saveInternalProductRoute.ts
+++ b/node/middlewares/internals/saveInternalProductRoute.ts
@@ -29,7 +29,9 @@ export async function saveInternalProductRoute(
 ) {
   const {
     clients: { apps, rewriterGraphql },
-    resources: { idUrlIndex },
+    state: {
+      resources: { idUrlIndex },
+    },
     vtex: { logger },
   } = ctx
   try {

--- a/node/middlewares/internals/saveInternalProductRoute.ts
+++ b/node/middlewares/internals/saveInternalProductRoute.ts
@@ -44,7 +44,7 @@ export async function saveInternalProductRoute(
 
     await Promise.all([
       rewriterGraphql.saveInternal(internal),
-      idUrlIndex.save(product.id, bindings, path),
+      idUrlIndex.save(product.id, path, bindings),
     ])
   } catch (error) {
     logger.error(error)

--- a/node/resources/idUrlIndex.ts
+++ b/node/resources/idUrlIndex.ts
@@ -1,17 +1,22 @@
 import { VBase } from '@vtex/api'
+import { RedirectInput, RedirectTypes } from 'vtex.rewriter'
+
+import { RewriterGraphql } from '../clients/rewriterGraphql'
 
 const INDEX = 'INDEX'
 const REVERSE_INDEX = 'ID_TO_URL'
 
 const toReverseIndexKey = (id: string, binding: string) => `${id}__${binding}`
-
+// TODO receives multiple bindings
 export class IdUrlIndex {
   private bucket: string
-  constructor(protected vbase: VBase) {
+  constructor(
+    protected vbase: VBase,
+    protected rewriterGraphql: RewriterGraphql
+  ) {
     this.bucket = `_${INDEX}_${REVERSE_INDEX}`
   }
 
-  // Additional methods for indexing of URLs by their corresponding ID in VTEX catalog.
   public get = async (id: string, binding: string) => {
     const key = toReverseIndexKey(id, binding)
     const response = await this.vbase.getJSON<string>(this.bucket, key, true)
@@ -19,6 +24,22 @@ export class IdUrlIndex {
   }
 
   public save = async (id: string, binding: string, url: string) => {
+    const canonical = await this.get(id, binding)
+    if (canonical && canonical !== url) {
+      const { id: canonicalId } = (await this.rewriterGraphql.getInternal(
+        url
+      )) || { id: null }
+      if (canonicalId !== id) {
+        const redirect: RedirectInput = {
+          bindings: [binding],
+          from: canonical,
+          to: url,
+          // endDate TODO ONE YEAR???
+          type: RedirectTypes.Temporary,
+        }
+        await this.rewriterGraphql.saveRedirect(redirect)
+      }
+    }
     const key = toReverseIndexKey(id, binding)
     const response = await this.vbase.saveJSON<string>(this.bucket, key, url)
     return response

--- a/node/resources/idUrlIndex.ts
+++ b/node/resources/idUrlIndex.ts
@@ -1,0 +1,26 @@
+import { VBase } from '@vtex/api'
+
+const INDEX = 'INDEX'
+const REVERSE_INDEX = 'ID_TO_URL'
+
+const toReverseIndexKey = (id: string, binding: string) => `${id}__${binding}`
+
+export class IdUrlIndex {
+  private bucket: string
+  constructor(protected vbase: VBase) {
+    this.bucket = `_${INDEX}_${REVERSE_INDEX}`
+  }
+
+  // Additional methods for indexing of URLs by their corresponding ID in VTEX catalog.
+  public get = async (id: string, binding: string) => {
+    const key = toReverseIndexKey(id, binding)
+    const response = await this.vbase.getJSON<string>(this.bucket, key, true)
+    return response
+  }
+
+  public save = async (id: string, binding: string, url: string) => {
+    const key = toReverseIndexKey(id, binding)
+    const response = await this.vbase.saveJSON<string>(this.bucket, key, url)
+    return response
+  }
+}

--- a/node/resources/idUrlIndex.ts
+++ b/node/resources/idUrlIndex.ts
@@ -6,12 +6,11 @@ import { RewriterGraphql } from '../clients/rewriterGraphql'
 const INDEX = 'INDEX'
 const REVERSE_INDEX = 'ID_TO_URL'
 
-const tenMinutesFromNowMS = () =>
-  `${new Date(Date.now() + 10 * 60 * 1000)}`
+const tenMinutesFromNowMS = () => `${new Date(Date.now() + 10 * 60 * 1000)}`
 
 const toReverseIndexKey = (id: string, bindings: string[]) =>
   `${id}__${bindings.join('_')}`
-// TODO receives multiple bindings
+
 export class IdUrlIndex {
   private bucket: string
   constructor(

--- a/node/resources/idUrlIndex.ts
+++ b/node/resources/idUrlIndex.ts
@@ -26,7 +26,7 @@ export class IdUrlIndex {
     return response
   }
 
-  public save = async (id: string, bindings: string[], url: string) => {
+  public save = async (id: string, url: string, bindings: string[] = ['*']) => {
     const canonical = (await this.get(id, bindings)) as string | null
     if (canonical && canonical !== url) {
       const { id: canonicalId } = (await this.rewriterGraphql.getInternal(

--- a/node/resources/index.ts
+++ b/node/resources/index.ts
@@ -5,6 +5,7 @@ export class Resources {
   public idUrlIndex: IdUrlIndex
 
   constructor(ctx: ColossusEventContext) {
-    this.idUrlIndex = new IdUrlIndex(ctx.clients.vbase)
+    const { vbase, rewriterGraphql } = ctx.clients
+    this.idUrlIndex = new IdUrlIndex(vbase, rewriterGraphql)
   }
 }

--- a/node/resources/index.ts
+++ b/node/resources/index.ts
@@ -1,0 +1,10 @@
+import { ColossusEventContext } from '../typings/Colossus'
+import { IdUrlIndex } from './idUrlIndex'
+
+export class Resources {
+  public idUrlIndex: IdUrlIndex
+
+  constructor(ctx: ColossusEventContext) {
+    this.idUrlIndex = new IdUrlIndex(ctx.clients.vbase)
+  }
+}

--- a/node/typings/Colossus.ts
+++ b/node/typings/Colossus.ts
@@ -10,10 +10,10 @@ export interface ColossusEventContext extends EventContext<Clients, State> {
   body: any
   clients: Clients
   state: State
-  resources: Resources
 }
 
 export interface State extends RecorderState {
+  resources: Resources
   tStringsByGroupContext: Array<[string, string[]]>
   searchURLs: Array<{ path: string; canonicalPath?: string }>
   settings: Settings

--- a/node/typings/Colossus.ts
+++ b/node/typings/Colossus.ts
@@ -2,6 +2,7 @@ import { EventContext, RecorderState, Tenant } from '@vtex/api'
 
 import { Clients } from '../clients'
 import { Settings } from '../middlewares/settings'
+import { Resources } from '../resources'
 
 export interface ColossusEventContext extends EventContext<Clients, State> {
   key: string
@@ -9,6 +10,7 @@ export interface ColossusEventContext extends EventContext<Clients, State> {
   body: any
   clients: Clients
   state: State
+  resources: Resources
 }
 
 export interface State extends RecorderState {


### PR DESCRIPTION
Saves a reverse index for routes,  from the route id to its URL. If there is a change in the canonical it updates the index and saves a redirect from the old route to the new one.