### PR TITLE
Saves routes with correct bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Saves routes with correct bindings
 
 ## [0.5.0] - 2020-01-30
 ### Added

--- a/node/middlewares/internals/saveInternalProductRoute.ts
+++ b/node/middlewares/internals/saveInternalProductRoute.ts
@@ -3,13 +3,19 @@ import { InternalInput } from 'vtex.rewriter'
 
 import { ColossusEventContext } from '../../typings/Colossus'
 import {
+  getBindings,
   getPath,
   PAGE_TYPES,
   STORE_LOCATOR,
   tenMinutesFromNowMS,
 } from './utils'
 
-const getProductInternal = (path: string, id: string): InternalInput => ({
+const getProductInternal = (
+  path: string,
+  id: string,
+  bindings: string[]
+): InternalInput => ({
+  bindings,
   declarer: STORE_LOCATOR,
   endDate: tenMinutesFromNowMS(),
   from: path,
@@ -36,9 +42,10 @@ export async function saveInternalProductRoute(
     const product: Product = ctx.body
     const slug = product.linkId?.toLowerCase()
     const path = await getPath(PAGE_TYPES.PRODUCT, { slug }, apps)
+    const bindings = getBindings(ctx.vtex.tenant, product.salesChannel)
 
     const internal: InternalInput = product.isActive
-      ? getProductInternal(path, product.id)
+      ? getProductInternal(path, product.id, bindings)
       : getProductNotFoundInternal(path)
 
     await rewriterGraphql.saveInternal(internal)

--- a/node/middlewares/internals/saveInternalProductRoute.ts
+++ b/node/middlewares/internals/saveInternalProductRoute.ts
@@ -42,7 +42,7 @@ export async function saveInternalProductRoute(
     const product: Product = ctx.body
     const slug = product.linkId?.toLowerCase()
     const path = await getPath(PAGE_TYPES.PRODUCT, { slug }, apps)
-    const bindings = getBindings(ctx.vtex.tenant, product.salesChannel)
+    const bindings = getBindings(ctx.state.tenantInfo, product.salesChannel)
 
     const internal: InternalInput = product.isActive
       ? getProductInternal(path, product.id, bindings)

--- a/node/middlewares/internals/utils.ts
+++ b/node/middlewares/internals/utils.ts
@@ -54,7 +54,7 @@ export const getBindings = (
   tenantInfo: any,
   salesChannels: Array<Maybe<SalesChannel>> | null | undefined
 ): string[] => {
-  if (!tenantInfo.bindings || !salesChannels || salesChannels.length === 0) {
+  if (!tenantInfo || !salesChannels || salesChannels.length === 0) {
     return ['*']
   }
   const mapSalesChannelToBindingId = tenantInfo.bindings.reduce(

--- a/node/middlewares/internals/utils.ts
+++ b/node/middlewares/internals/utils.ts
@@ -31,7 +31,6 @@ export type Routes = Record<string, ContentTypeDefinition>
 
 type PageTypes = typeof PAGE_TYPES[keyof typeof PAGE_TYPES]
 
-
 export const getPath = async (
   type: PageTypes,
   params: any,
@@ -53,14 +52,14 @@ export const getPath = async (
 
 export const getBindings = (
   tenantInfo: any,
-  salesChannel: Maybe<SalesChannel[]>
+  salesChannels: Array<Maybe<SalesChannel>> | null | undefined
 ): string[] => {
-  if (!tenantInfo.bindings || !salesChannel) {
+  if (!tenantInfo.bindings || !salesChannels || salesChannels.length === 0) {
     return ['*']
   }
   const mapSalesChannelToBindingId = tenantInfo.bindings.reduce(
-    (acc: Record<string, string>, { id, extraContent }: any) => {
-      const salesChannelId = extraContent.salesChannel
+    (acc: Record<string, string>, { id, extraContext }: any) => {
+      const salesChannelId = extraContext.portal?.salesChannel
       if (salesChannelId) {
         acc[salesChannelId] = id
       }
@@ -69,5 +68,7 @@ export const getBindings = (
     {} as Record<string, string>
   )
 
-  return salesChannel.map(({ id }) => mapSalesChannelToBindingId[id])
+  return salesChannels.map(
+    salesChannel => salesChannel && mapSalesChannelToBindingId[salesChannel.id]
+  )
 }

--- a/node/middlewares/internals/utils.ts
+++ b/node/middlewares/internals/utils.ts
@@ -1,5 +1,6 @@
 import { Apps } from '@vtex/api'
 import RouteParser from 'route-parser'
+import { Maybe, SalesChannel } from 'vtex.catalog-graphql'
 
 export const tenMinutesFromNowMS = () =>
   `${new Date(Date.now() + 10 * 60 * 1000)}`
@@ -27,7 +28,9 @@ export interface ContentTypeDefinition {
 }
 
 export type Routes = Record<string, ContentTypeDefinition>
+
 type PageTypes = typeof PAGE_TYPES[keyof typeof PAGE_TYPES]
+
 
 export const getPath = async (
   type: PageTypes,
@@ -46,4 +49,25 @@ export const getPath = async (
     throw new Error(`Parse error, params: ${params}, path: ${path}`)
   }
   return path
+}
+
+export const getBindings = (
+  tenantInfo: any,
+  salesChannel: Maybe<SalesChannel[]>
+): string[] => {
+  if (!tenantInfo.bindings || !salesChannel) {
+    return ['*']
+  }
+  const mapSalesChannelToBindingId = tenantInfo.bindings.reduce(
+    (acc: Record<string, string>, { id, extraContent }: any) => {
+      const salesChannelId = extraContent.salesChannel
+      if (salesChannelId) {
+        acc[salesChannelId] = id
+      }
+      return acc
+    },
+    {} as Record<string, string>
+  )
+
+  return salesChannel.map(({ id }) => mapSalesChannelToBindingId[id])
 }

--- a/node/middlewares/internals/utils.ts
+++ b/node/middlewares/internals/utils.ts
@@ -68,7 +68,10 @@ export const getBindings = (
     {} as Record<string, string>
   )
 
-  return salesChannels.map(
-    salesChannel => salesChannel && mapSalesChannelToBindingId[salesChannel.id]
-  )
+  return salesChannels.reduce((acc, salesChannel) => {
+    if (salesChannel) {
+      acc.push(mapSalesChannelToBindingId[salesChannel.id])
+    }
+    return acc
+  }, [] as string[])
 }

--- a/node/middlewares/tenant.ts
+++ b/node/middlewares/tenant.ts
@@ -3,38 +3,40 @@ import { ColossusEventContext } from '../typings/Colossus'
 
 const TEN_MINUTES_S = 10 * 60
 
-const getTenant = async (
-  clients: Clients
-): Promise<{ tenantInfo: any; locale: string }> => {
-  const { segment, tenant: tenantClient } = clients
-  const [segmentData, tenantInfo] = await Promise.all([
-    segment.getSegmentByToken(null),
-    tenantClient
-      .info({
-        forceMaxAge: TEN_MINUTES_S,
-        nullIfNotFound: true,
-      })
-      .catch((_: any) => undefined),
-  ])
+const getHeaders = async (
+  clients: Clients,
+  tenantInfo: any
+): Promise<{ tenantHeader: { locale: string }; locale: string }> => {
+  const { segment } = clients
+  const segmentData = await segment.getSegmentByToken(null)
   const cultureFromTenant = tenantInfo && tenantInfo.defaultLocale
   const cultureFromDefaultSegment = segmentData!.cultureInfo
   const locale = cultureFromTenant || cultureFromDefaultSegment
 
   return {
     locale,
-    tenantInfo: tenantInfo || { locale },
+    tenantHeader: { locale },
   }
 }
+
+const getTenant = (clients: Clients) =>
+  clients.tenant
+    .info({
+      forceMaxAge: TEN_MINUTES_S,
+      nullIfNotFound: true,
+    })
+    .catch((_: any) => undefined)
 
 export async function tenant(
   ctx: ColossusEventContext,
   next: () => Promise<any>
 ) {
+  const tenantInfo = await getTenant(ctx.clients)
+  ctx.state.tenantInfo = tenantInfo
   if (!ctx.vtex.tenant || !ctx.vtex.locale) {
-    const { locale, tenantInfo } = await getTenant(ctx.clients)
-
+    const { locale, tenantHeader } = await getHeaders(ctx.clients, tenantInfo)
     ctx.vtex.locale = locale
-    ctx.vtex.tenant = tenantInfo
+    ctx.vtex.tenant = tenantHeader
   }
   await next()
 }

--- a/node/typings/Colossus.ts
+++ b/node/typings/Colossus.ts
@@ -15,6 +15,7 @@ export interface State {
   tStringsByGroupContext: Array<[string, string[]]>
   searchURLs: Array<{ path: string; canonicalPath?: string }>
   settings: Settings
+  tenantInfo: any
 }
 
 export interface ColossusEvent {


### PR DESCRIPTION
# What this PR does?

Adds a function to get the bindings id of the product, to do this it matches the sales channels of the product with the sales channels of the bindings. If the account is not in the tenant system is uses the default binding `*`.

> Note: there is some `any` type for the tenant info. This will be addressed when converting to node 6.x

Depends on: https://github.com/vtex-apps/broadcaster-listener/pull/28