### PR TITLE
Processes one category instead of going up the category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stops going up the category tree
 
 ## [0.12.0] - 2020-04-08
 ### Addded

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -17,16 +17,16 @@ interface IdentifiedCategory extends Category {
 }
 
 const getCategoryType = (
-  parentsNames: string[]
+  categoryTree: string[]
 ): { type: CategoryTypes; map: string; params: Record<string, string> } => {
-  const height = parentsNames.length
-  const slugifiedParentsNames = parentsNames.map(slugify)
+  const height = categoryTree.length
+  const slugifiedCategoryTree = categoryTree.map(slugify)
   switch (height) {
     case 1:
       return {
         map: 'c',
         params: {
-          department: slugifiedParentsNames[0],
+          department: slugifiedCategoryTree[0],
         },
         type: 'DEPARTMENT',
       }
@@ -34,8 +34,8 @@ const getCategoryType = (
       return {
         map: 'c,c',
         params: {
-          category: slugifiedParentsNames[1],
-          department: slugifiedParentsNames[0],
+          category: slugifiedCategoryTree[1],
+          department: slugifiedCategoryTree[0],
         },
         type: 'CATEGORY',
       }
@@ -45,10 +45,10 @@ const getCategoryType = (
           .fill('c')
           .join(','),
         params: {
-          category: slugifiedParentsNames[1],
-          department: slugifiedParentsNames[0],
-          subcategory: slugifiedParentsNames[2],
-          terms: slugifiedParentsNames.slice(3).join('/'),
+          category: slugifiedCategoryTree[1],
+          department: slugifiedCategoryTree[0],
+          subcategory: slugifiedCategoryTree[2],
+          terms: slugifiedCategoryTree.slice(3).join('/'),
         },
         type: 'SUBCATEGORY',
       }

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -12,86 +12,47 @@ import { slugify } from '../../utils/slugify'
 
 type CategoryTypes = 'DEPARTMENT' | 'CATEGORY' | 'SUBCATEGORY'
 
-interface IdentifiedCategory {
-  type: CategoryTypes
-  map: string
-  id: string
-  params: {
-    department?: string
-    category?: string
-    subcategory?: string
-    terms?: string
-  }
-  isActive: boolean
+interface IdentifiedCategory extends Category {
+  parentsNames: string[]
 }
 
-const categoriesFromCategoryTree = async (
-  category: Category,
-  ctx: Context
-): Promise<IdentifiedCategory[]> => {
-  const { catalogGraphQL } = ctx.clients
-  const { parentCategoryId, name } = category
-
-  if (!parentCategoryId) {
-    const identifiedCategory: IdentifiedCategory = {
-      id: category.id,
-      isActive: category.isActive,
-      map: 'c',
-      params: {
-        department: slugify(name),
-      },
-      type: 'DEPARTMENT',
-    }
-    return [identifiedCategory]
+const getCategoryType = (
+  parentsNames: string[]
+): { type: CategoryTypes; map: string; params: Record<string, string> } => {
+  const height = parentsNames.length
+  const slugifiedParentsNames = parentsNames.map(slugify)
+  switch (height) {
+    case 1:
+      return {
+        map: 'c',
+        params: {
+          department: slugifiedParentsNames[0],
+        },
+        type: 'DEPARTMENT',
+      }
+    case 2:
+      return {
+        map: 'c,c',
+        params: {
+          category: slugifiedParentsNames[1],
+          department: slugifiedParentsNames[0],
+        },
+        type: 'CATEGORY',
+      }
+    default:
+      return {
+        map: Array(height)
+          .fill('c')
+          .join(','),
+        params: {
+          category: slugifiedParentsNames[1],
+          department: slugifiedParentsNames[0],
+          subcategory: slugifiedParentsNames[2],
+          terms: slugifiedParentsNames.slice(3).join('/'),
+        },
+        type: 'SUBCATEGORY',
+      }
   }
-
-  const parentCategory = await catalogGraphQL
-    .category(parentCategoryId)
-    .then(res => res!.category)
-
-  const identifiedCategories = await categoriesFromCategoryTree(
-    parentCategory,
-    ctx
-  )
-  const { type, params, map } = identifiedCategories[0]
-
-  if (type === 'DEPARTMENT') {
-    const identifiedCategory: IdentifiedCategory = {
-      id: category.id,
-      isActive: category.isActive,
-      map: `${map},c`,
-      params: {
-        ...params,
-        category: slugify(name),
-      },
-      type: 'CATEGORY',
-    }
-    return [identifiedCategory, ...identifiedCategories]
-  }
-  if (type === 'CATEGORY') {
-    const identifiedCategory: IdentifiedCategory = {
-      id: category.id,
-      isActive: category.isActive,
-      map: `${map},c`,
-      params: {
-        ...params,
-        subcategory: slugify(name),
-      },
-      type: 'SUBCATEGORY',
-    }
-    return [identifiedCategory, ...identifiedCategories]
-  }
-  const identifiedCategory = {
-    id: category.id,
-    isActive: category.isActive,
-    map: `${map},c`,
-    params: {
-      ...params,
-      terms: params.terms ? `${params.terms}${slugify(name)}` : slugify(name),
-    },
-    type,
-  }
-  return [identifiedCategory, ...identifiedCategories]
 }
 
 export async function categoryInternals(
@@ -102,39 +63,33 @@ export async function categoryInternals(
     clients: { apps },
     state,
   } = ctx
-  const category: Category = ctx.body
+  const category: IdentifiedCategory = ctx.body
   const bindings = filterStoreBindings(ctx.state.tenantInfo)
 
   if (bindings.length === 0) {
     return
   }
+  const { id, isActive, name, parentsNames } = category
+  const { map, type, params } = getCategoryType([...parentsNames, name])
+  const pageType = PAGE_TYPES[type]
+  const formatRoute = await routeFormatter(apps, pageType)
+  const internals = bindings.map(binding => {
+    const { id: bindingId } = binding
+    const translatedParams = params
+    const path = formatRoute(translatedParams)
 
-  const categories = await categoriesFromCategoryTree(category, ctx)
+    return {
+      binding: bindingId,
+      declarer: STORE_LOCATOR,
+      from: path,
+      id,
+      origin: INDEXED_ORIGIN,
+      query: isActive ? { map } : null,
+      type: isActive ? pageType : PAGE_TYPES.SEARCH_NOT_FOUND,
+    }
+  })
 
-  const internals = await Promise.all(
-    categories.map(async cat => {
-      const { type, params, id, isActive, map } = cat
-      const pageType = PAGE_TYPES[type]
-      const formatRoute = await routeFormatter(apps, pageType)
-      return bindings.map(binding => {
-        const { id: bindingId } = binding
-        const translatedParams = params
-        const path = formatRoute(translatedParams)
-
-        return {
-          binding: bindingId,
-          declarer: STORE_LOCATOR,
-          from: path,
-          id,
-          origin: INDEXED_ORIGIN,
-          query: isActive ? { map } : null,
-          type: isActive ? pageType : PAGE_TYPES.SEARCH_NOT_FOUND,
-        }
-      })
-    })
-  )
-
-  state.internals = internals.flat()
+  state.internals = internals
 
   await next()
 }

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.24.3",
+    "@vtex/api": "6.24.4",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.24.3":
-  version "6.24.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.24.3.tgz#8b60e8ddf9440528cbec6233d99a818b5afb6bb8"
-  integrity sha512-0DID7jBZfP6awgVieoKW29NcBbqwW4WBupD3WRMUzBjSLN87ucX4srY2XiQD68/ACUtP/9dByt8ijJNTEv03ZA==
+"@vtex/api@6.24.4":
+  version "6.24.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.24.4.tgz#e39c5c87c01fe287ce0aaac9acc7c7acd224f7a1"
+  integrity sha512-w/wSmNQjvG0CQBGic/KPGD4l+yGIam2LMORlubt68bb6qA5j/21Fijfy8N9HFEwo+rmQAYnutMJGVzSQUlBh9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1580,7 +1580,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**
Depends on: https://github.com/vtex-apps/broadcaster-worker/pull/8
Updates store-indexer according to the PR above. It now stops going up the category tree and process only the received category.

**How should this be manually tested?**

**Screenshots or example usage:**