### PR TITLE
Fixes filter bindings by sales channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Fixes filte bindings by sales channel
 
 ## [0.13.0] - 2020-04-13
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-indexer",
   "vendor": "vtex",
-  "version": "0.13.0",
+  "version": "0.13.1-beta.0",
   "title": "Store Indexer",
   "description": "Listens to  IO-broadcaster for catalog itens changes.",
   "mustUpdateAt": "2020-07-29",
@@ -73,8 +73,6 @@
       "name": "vtex.rewriter:resolve-graphql"
     }
   ],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/utils/bindings.ts
+++ b/node/utils/bindings.ts
@@ -14,8 +14,10 @@ export const filterBindingsBySalesChannel = (
 
   return tenantInfo.bindings.filter(binding => {
     if (binding.targetProduct === 'vtex-storefront') {
-      const bindingSC = binding.extraContext.portal?.salesChannel
-      const productActiveInBindingSC = salesChannelsSet?.has(bindingSC)
+      const bindingSC: number | undefined =
+        binding.extraContext.portal?.salesChannel
+      const productActiveInBindingSC =
+        bindingSC && salesChannelsSet?.has(bindingSC.toString())
       if (productActiveInBindingSC || !salesChannelsSet) {
         return true
       }


### PR DESCRIPTION
**What problem is this solving?**
Sometimes the sales channel types are different, from the product and the tenant info. 
Causing all products not to be indexed

**How should this be manually tested?**

**Screenshots or example usage:**