### PR TITLE
add graphqlServer client

### DIFF
--- a/node/clients/graphqlServer.ts
+++ b/node/clients/graphqlServer.ts
@@ -1,0 +1,24 @@
+import { AppClient, GraphQLClient, InstanceOptions, IOContext, RequestConfig } from '@vtex/api'
+
+export class GraphQLServer extends AppClient {
+  protected graphql: GraphQLClient
+
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super('vtex.graphql-server@1.x', ctx, opts)
+    this.graphql = new GraphQLClient(this.http)
+  }
+
+  public query = async (query: string, variables: any, extensions: any, config: RequestConfig) => {
+    return this.graphql.query(
+      {
+        extensions,
+        query,
+        variables,
+      },
+      {
+        ...config,
+        url: '/graphql',
+      }
+    )
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -2,6 +2,7 @@
 import { IOClients } from '@vtex/api'
 
 import { Catalog } from './catalog'
+import { GraphQLServer } from './graphqlServer'
 import { Rewriter } from './rewriter'
 import { SearchGraphql } from './searchGraphql'
 
@@ -16,5 +17,9 @@ export class Clients extends IOClients {
 
   get rewriter() {
     return this.getOrSet('rewriter', Rewriter)
+  }
+
+  get graphqlServer() {
+    return this.getOrSet('graphqlServer', GraphQLServer)
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1580,7 +1580,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**
As a result of the search plug and play feature, the `search-graphql` will no longer have its implementation, instead, another app will implement its graphql schema. For this reason, we have to remove all the calls that once were made directly to `search-graphql` and direct them to `graphql-server` that will forward the query for the app that implements the search.
