### PR TITLE
Translate from catalog graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Listens to events raised by catalog-graphql
+
+### Fixed
+- translate before lowering the string, so product link are translated correctly
 
 ## [0.13.1] - 2020-04-14
 ### Fixed 

--- a/node/index.ts
+++ b/node/index.ts
@@ -58,12 +58,19 @@ const clients: ClientsConfig<Clients> = {
   },
 }
 
+const brand = [throttle, tenant, brandInternals, saveInternals]
+const category = [throttle, tenant, categoryInternals, saveInternals]
+const product = [throttle, tenant, productInternals, saveInternals]
+
 export default new Service<Clients, State, ParamsContext>({
   clients,
   events: {
-    broadcasterBrand: [throttle, tenant, brandInternals, saveInternals],
-    broadcasterCategory: [throttle, tenant, categoryInternals, saveInternals],
-    broadcasterProduct: [throttle, tenant, productInternals, saveInternals],
+    broadcasterBrand: brand,
+    broadcasterCategory: category,
+    broadcasterProduct: product,
+    catalogBrand: brand,
+    catalogCategory: category,
+    catalogProduct: product,
     searchUrlsCountIndex: [
       throttle,
       settings,

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -24,19 +24,18 @@ export async function productInternals(
   } = ctx
   const product: Product = ctx.body
   const { linkId, isActive, id } = product
-  const slug = linkId?.toLowerCase()
   const bindings = filterBindingsBySalesChannel(
     tenantInfo,
     product.salesChannel
   )
 
-  if (!slug || bindings.length === 0) {
+  if (!linkId || bindings.length === 0) {
     return
   }
 
   const formatRoute = await routeFormatter(apps, PAGE_TYPES.PRODUCT)
   const translate = createTranslator(messagesGraphQL)
-  const messages = [{ content: slug, context: id }]
+  const messages = [{ content: linkId, context: id }]
 
   const internals = await Promise.all(
     bindings.map(async binding => {

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.24.4",
+    "@vtex/api": "6.25.0",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",

--- a/node/service.json
+++ b/node/service.json
@@ -18,6 +18,18 @@
       "sender": "vtex.broadcaster-worker",
       "keys": ["broadcaster.category"]
     },
+    "catalogBrand": {
+      "sender": "vtex.catalog-graphql",
+      "keys": ["broadcaster.brand"]
+    },
+    "catalogCategory": {
+      "sender": "vtex.catalog-graphql",
+      "keys": ["broadcaster.category"]
+    },
+    "catalogProduct": {
+      "sender": "vtex.catalog-graphql",
+      "keys": ["broadcaster.product"]
+    },
     "searchUrlsCountIndex": {
       "sender": "vtex.search-graphql",
       "keys": ["searchUrlsCountIndex"]

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.24.4":
-  version "6.24.4"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.24.4.tgz#e39c5c87c01fe287ce0aaac9acc7c7acd224f7a1"
-  integrity sha512-w/wSmNQjvG0CQBGic/KPGD4l+yGIam2LMORlubt68bb6qA5j/21Fijfy8N9HFEwo+rmQAYnutMJGVzSQUlBh9A==
+"@vtex/api@6.25.0":
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.25.0.tgz#5d64fa74d34ffec67b3e7859bab837104dd21047"
+  integrity sha512-uMIr5FXnw//wiQokIYftf8nB+2vDc1bWFl2XYcChJdTv6So932BK8jBv+wQuc/eN/8BP4M/m0zcghjiejhw4pw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**
Listens to events raised by `vtex.catalog-graphql`.

Also, this PR fixes the slug translation

**How should this be manually tested?**

**Screenshots or example usage:**