### PR TITLE
Remove messages cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removes cache from messages so we are always fresh
 
 ## [0.14.1] - 2020-04-16
 ### Removed

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/explicit-member-accessibility */
 import { IOClients } from '@vtex/api'
 
 import { Catalog } from './catalog'
+import { Messages } from './messages'
 import { Rewriter } from './rewriter'
 import { SearchGraphql } from './searchGraphql'
 
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
 export class Clients extends IOClients {
   get searchGraphql() {
     return this.getOrSet('searchGraphql', SearchGraphql)
@@ -16,5 +17,9 @@ export class Clients extends IOClients {
 
   get rewriter() {
     return this.getOrSet('rewriter', Rewriter)
+  }
+
+  get messages() {
+    return this.getOrSet('messages', Messages)
   }
 }

--- a/node/clients/messages.ts
+++ b/node/clients/messages.ts
@@ -1,0 +1,30 @@
+import { MessagesGraphQL } from '@vtex/api'
+import { Query, TranslateArgs } from 'vtex.messages'
+
+interface Response {
+  translate: Query['translate']
+}
+
+interface Variables {
+  args: TranslateArgs
+}
+
+export class Messages extends MessagesGraphQL {
+  public async translateNoCache(args: TranslateArgs) {
+    const response = await this.graphql.query<Response, Variables>(
+      {
+        query: `query Translate($args: TranslateArgs!) {
+          translate(args: $args)
+        }`,
+        variables: { args },
+      },
+      {
+        headers: {
+          'cache-control': 'no-cache',
+        },
+        metric: 'messages-translate-v2',
+      }
+    )
+    return response.data!.translate as string[]
+  }
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -20,7 +20,7 @@ import { throttle } from './middlewares/throttle'
 import { State } from './typings/global'
 
 const TIMEOUT_MS = 3000
-const TRANSLATION_CONCURRENCY = 5
+const TRANSLATION_CONCURRENCY = 10
 const TRANSLATION_RETRIES = 3
 const CONCURRENCY = 10
 
@@ -46,7 +46,7 @@ const clients: ClientsConfig<Clients> = {
       retries: 2,
       timeout: TIMEOUT_MS,
     },
-    messagesGraphQL: {
+    messages: {
       concurrency: TRANSLATION_CONCURRENCY,
       retries: TRANSLATION_RETRIES,
       timeout: TIMEOUT_MS,

--- a/node/middlewares/internals/brand.ts
+++ b/node/middlewares/internals/brand.ts
@@ -13,7 +13,7 @@ import { slugify } from '../../utils/slugify'
 
 export async function brandInternals(ctx: Context, next: () => Promise<void>) {
   const {
-    clients: { apps, messagesGraphQL },
+    clients: { apps, messages: messagesClient },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -28,7 +28,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
   }
 
   const formatRoute = await routeFormatter(apps, PAGE_TYPES.BRAND)
-  const translate = createTranslator(messagesGraphQL)
+  const translate = createTranslator(messagesClient)
   const messages = [{ content: name, context: id }]
 
   const internals = await Promise.all(

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -54,7 +54,7 @@ export async function categoryInternals(
   next: () => Promise<void>
 ) {
   const {
-    clients: { apps, messagesGraphQL },
+    clients: { apps, messages: messagesClient },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -76,7 +76,7 @@ export async function categoryInternals(
   }))
 
   const formatRoute = await routeFormatter(apps, pageType)
-  const translate = createTranslator(messagesGraphQL)
+  const translate = createTranslator(messagesClient)
 
   const internals = await Promise.all(
     bindings.map(async binding => {

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -16,7 +16,7 @@ export async function productInternals(
   next: () => Promise<void>
 ) {
   const {
-    clients: { apps, messagesGraphQL },
+    clients: { apps, messages: messagesClient },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -34,7 +34,7 @@ export async function productInternals(
   }
 
   const formatRoute = await routeFormatter(apps, PAGE_TYPES.PRODUCT)
-  const translate = createTranslator(messagesGraphQL)
+  const translate = createTranslator(messagesClient)
   const messages = [{ content: linkId, context: id }]
 
   const internals = await Promise.all(

--- a/node/utils/messages.ts
+++ b/node/utils/messages.ts
@@ -1,11 +1,11 @@
-import { MessagesGraphQL } from '@vtex/api'
+import { Messages } from '../clients/messages'
 
 interface Message {
   content: string
   context: string
 }
 
-export const createTranslator = (service: MessagesGraphQL) => async (
+export const createTranslator = (service: Messages) => async (
   from: string,
   to: string,
   messages: Message[]
@@ -13,7 +13,7 @@ export const createTranslator = (service: MessagesGraphQL) => async (
   if (from.toLowerCase() === to.toLowerCase()) {
     return messages.map(({ content }) => content)
   }
-  const translations = await service.translate({
+  const translations = await service.translateNoCache({
     indexedByFrom: [
       {
         from,


### PR DESCRIPTION
**What problem is this solving?**
Currently we may hit the message's cache. To avoid this problem, I've added a client for messages that call the service with the header `cache-control: 'no-cache'`. This makes kube-router not to respond from cache and actually call vtex.messages service

**How should this be manually tested?**

**Screenshots or example usage:**