### PR TITLE
Saves origin with complete app name and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Saves origin with complete app name and version
 
 ## [0.15.0] - 2020-05-20
 

--- a/node/utils/internals.ts
+++ b/node/utils/internals.ts
@@ -2,7 +2,7 @@
 import { Apps } from '@vtex/api'
 import RouteParser from 'route-parser'
 
-export const INDEXED_ORIGIN = 'vtex.store-indexer@0.x:routes-indexing'
+export const INDEXED_ORIGIN = `${process.env.VTEX_APP_ID!}:routes-indexing`
 export const STORE_LOCATOR = 'vtex.store@2.x'
 export const ROUTES_JSON_PATH = 'dist/vtex.store-indexer/build.json'
 


### PR DESCRIPTION
And fixes subcategory longer than 3 bug due to canonical not having `*terms` in the end https://github.com/vtex-apps/store/pull/444