### PR TITLE
Handles missing tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Throws 404 error when tenant is not found
 
 ## [0.14.3] - 2020-05-06
 ### Fixed

--- a/node/middlewares/tenant.ts
+++ b/node/middlewares/tenant.ts
@@ -1,3 +1,5 @@
+import { NotFoundError } from '@vtex/api'
+
 import { Context } from '../typings/global'
 
 const TEN_MINUTES_S = 10 * 60
@@ -5,11 +7,17 @@ const TEN_MINUTES_S = 10 * 60
 export async function tenant(ctx: Context, next: () => Promise<void>) {
   const {
     clients: { tenant: tenantClient },
+    vtex: { account, logger },
   } = ctx
   const tenantInfo = await tenantClient.info({
     forceMaxAge: TEN_MINUTES_S,
     nullIfNotFound: true,
   })
+  if (!tenantInfo) {
+    logger.error(`Account ${account} not in tenant system`)
+    ctx.body = `Account ${account} not in tenant system`
+    throw NotFoundError
+  }
   const locale = tenantInfo.defaultLocale
 
   ctx.state.tenantInfo = tenantInfo

--- a/node/middlewares/tenant.ts
+++ b/node/middlewares/tenant.ts
@@ -1,5 +1,3 @@
-import { NotFoundError } from '@vtex/api'
-
 import { Context } from '../typings/global'
 
 const TEN_MINUTES_S = 10 * 60
@@ -7,17 +5,11 @@ const TEN_MINUTES_S = 10 * 60
 export async function tenant(ctx: Context, next: () => Promise<void>) {
   const {
     clients: { tenant: tenantClient },
-    vtex: { account, logger },
   } = ctx
   const tenantInfo = await tenantClient.info({
     forceMaxAge: TEN_MINUTES_S,
-    nullIfNotFound: true,
   })
-  if (!tenantInfo) {
-    logger.error(`Account ${account} not in tenant system`)
-    ctx.body = `Account ${account} not in tenant system`
-    throw NotFoundError
-  }
+
   const locale = tenantInfo.defaultLocale
 
   ctx.state.tenantInfo = tenantInfo

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.25.0",
+    "@vtex/api": "6.28.1",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.25.0":
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.25.0.tgz#5d64fa74d34ffec67b3e7859bab837104dd21047"
-  integrity sha512-uMIr5FXnw//wiQokIYftf8nB+2vDc1bWFl2XYcChJdTv6So932BK8jBv+wQuc/eN/8BP4M/m0zcghjiejhw4pw==
+"@vtex/api@6.28.1":
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.28.1.tgz#36ae0535bde187f0bf84c69d41bf30f3c38f5ea6"
+  integrity sha512-9lpRwHPPXsyrbwkgbFgMp5/ENvaqS5TVJ7VtOXtRo5HjjEKrRCRO2vhPnocCDYj0O1Msk41Awj30HMZ5MpblFw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -171,7 +171,7 @@
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
     graphql-upload "^8.1.0"
-    jaeger-client "^3.17.2"
+    jaeger-client "^3.18.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
     koa-compose "^4.1.0"
@@ -965,13 +965,13 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
-jaeger-client@^3.17.2:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.17.2.tgz#92cf26752c5c66f3e66adf595cdde2f548cc0804"
-  integrity sha512-19YloSidmKbrXHgecLWod8eXo7rm2ieUnsfg0ripTFGRCW5v2OWE96Gte4/tOQG/8N+T39VoLU2nMBdjbdMUJg==
+jaeger-client@^3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.18.0.tgz#95c9183e06a9b14b957bce33b5e2ddaecb2ed51f"
+  integrity sha512-xZ9WvZDWLkZFq7SObpLwu1asMCKCgBRNcDxxGSvK+ZQ7OZyJC5xPlU+rJa4+s/P6autPBVwHpqMGbOERFxWuuA==
   dependencies:
     node-int64 "^0.4.0"
-    opentracing "^0.13.0"
+    opentracing "^0.14.4"
     thriftrw "^3.5.0"
     uuid "^3.2.1"
     xorshift "^0.2.0"
@@ -1339,11 +1339,6 @@ only@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
-
-opentracing@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.13.0.tgz#6a341442f09d7d866bc11ed03de1e3828e3d6aab"
-  integrity sha1-ajQUQvCdfYZrwR7QPeHjgo49aqs=
 
 opentracing@^0.14.4:
   version "0.14.4"


### PR DESCRIPTION
Currently a tenantless account causes an 500 error, this can cause this app to open the circuit if it receives too much requests from this types of accounts. This PR makes the request return a 404 in this situation.