### PR TITLE
Feature/resolve as

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-indexer",
   "vendor": "vtex",
-  "version": "0.15.0-beta.0",
+  "version": "0.15.0-beta.1",
   "title": "Store Indexer",
   "description": "Listens to  IO-broadcaster for catalog itens changes.",
   "mustUpdateAt": "2020-07-29",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-indexer",
   "vendor": "vtex",
-  "version": "0.14.4",
+  "version": "0.15.0-beta.0",
   "title": "Store Indexer",
   "description": "Listens to  IO-broadcaster for catalog itens changes.",
   "mustUpdateAt": "2020-07-29",
@@ -73,8 +73,6 @@
       "name": "vtex.rewriter:resolve-graphql"
     }
   ],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/middlewares/internals/brand.ts
+++ b/node/middlewares/internals/brand.ts
@@ -11,6 +11,11 @@ import {
 import { createTranslator } from '../../utils/messages'
 import { slugify } from '../../utils/slugify'
 
+type Params = Record<string, string | undefined> | null | undefined
+
+const pathFromRoute = (formatRoute: (x: Params) => string, brand: string) =>
+  formatRoute({ brand: slugify(brand).toLowerCase() })
+
 export async function brandInternals(ctx: Context, next: () => Promise<void>) {
   const {
     clients: { apps, messages: messagesClient },
@@ -31,6 +36,8 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
   const translate = createTranslator(messagesClient)
   const messages = [{ content: name, context: id }]
 
+  const tenantPath = pathFromRoute(formatRoute, name)
+
   const internals = await Promise.all(
     bindings.map(async binding => {
       const { id: bindingId, defaultLocale: bindingLocale } = binding
@@ -39,8 +46,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
         bindingLocale,
         messages
       )
-      const translatedSlug = slugify(translated).toLowerCase()
-      const path = formatRoute({ brand: translatedSlug })
+      const path = pathFromRoute(formatRoute, translated)
 
       return {
         binding: bindingId,
@@ -49,6 +55,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
         id,
         origin: INDEXED_ORIGIN,
         query: active ? { map: 'b' } : null,
+        resolveAs: tenantPath,
         type: active ? PAGE_TYPES.BRAND : PAGE_TYPES.SEARCH_NOT_FOUND,
       }
     })

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.28.1",
+    "@vtex/api": "6.30.0",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1588,7 +1588,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,13 +148,14 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.28.1":
-  version "6.28.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.28.1.tgz#36ae0535bde187f0bf84c69d41bf30f3c38f5ea6"
-  integrity sha512-9lpRwHPPXsyrbwkgbFgMp5/ENvaqS5TVJ7VtOXtRo5HjjEKrRCRO2vhPnocCDYj0O1Msk41Awj30HMZ5MpblFw==
+"@vtex/api@6.30.0":
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.0.tgz#9287828804a9b00fa16ab025d530203c4a9464cc"
+  integrity sha512-1VkhwebJYCY7sBdUH3KD2+PTxpX+BiXgVrisXRC07kbaxghzRdJ8oJcjhiSjvEHovjHCBtIHQbTuaM48dRNg5g==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
+    "@vtex/node-error-report" "^0.0.2"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
@@ -192,6 +193,13 @@
     tar-fs "^2.0.0"
     uuid "^3.3.3"
     xss "^1.0.6"
+
+"@vtex/node-error-report@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
+  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+  dependencies:
+    is-stream "^2.0.0"
 
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
@@ -944,6 +952,11 @@ is-retry-allowed@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 isarray@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
**What problem is this solving?**
Adds resolveAs field to internal routes of rewriter. resolveAs will always default to the tenant's original fields

**How should this be manually tested?**

**Screenshots or example usage:**