### PR TITLE
Fixes subcategory longer than 3 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.15.1] - 2020-05-27
 ### Fixed
 - Saves origin with complete app name and version
+- Fixes subcategory deeper than 3 bug
 
 ## [0.15.0] - 2020-05-20
 

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.30.0",
+    "@vtex/api": "6.30.1",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",

--- a/node/utils/internals.ts
+++ b/node/utils/internals.ts
@@ -41,6 +41,8 @@ export const routeFormatter = async (apps: Apps, type: PageTypes) => {
     STORE_LOCATOR,
     ROUTES_JSON_PATH
   )
+  routesJSON.subcategory.canonical =
+    '/:department/:category/:subcategory(/*terms)'
   const route = routesJSON[type]
   const canonicalParser = new RouteParser(route.canonical)
   return (params?: Record<string, string | undefined> | null) => {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.30.0":
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.0.tgz#9287828804a9b00fa16ab025d530203c4a9464cc"
-  integrity sha512-1VkhwebJYCY7sBdUH3KD2+PTxpX+BiXgVrisXRC07kbaxghzRdJ8oJcjhiSjvEHovjHCBtIHQbTuaM48dRNg5g==
+"@vtex/api@6.30.1":
+  version "6.30.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.1.tgz#e71ebed6cff6bfdec928535133ffe6d0522797ae"
+  integrity sha512-HfE5Jxii3daU8s3B0FS/5fKeoObkqZkdGBSz8iwWvhYN+nCrvJWm7J0KT5MyGNphp0E3ShxoHQhF46RUG8yXVA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1588,7 +1588,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
https://github.com/vtex-apps/store-indexer/pull/38

The subcategory canonical does not have (*terms) in the end so store-indexer saves subcategories with more than 3 segments wrongly. For example:

subcategory `/apparel/apparel-accessories/headwear/ball-heads` is saved as 
```
"from": "/apparel/apparel-accessories/headwear",
        "declarer": "vtex.store@2.x",
        "type": "subcategory",
        "id": "623",
        "query": {
          "map": "c,c,c,c"
        },
```