### PR TITLE
Deletes old routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Deletes previous routes, before updatnig route
 
 ## [0.15.2] - 2020-05-28
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-indexer",
   "vendor": "vtex",
-  "version": "0.15.2",
+  "version": "0.15.3-beta.0",
   "title": "Store Indexer",
   "description": "Listens to  IO-broadcaster for catalog itens changes.",
   "mustUpdateAt": "2020-07-29",
@@ -73,8 +73,6 @@
       "name": "vtex.rewriter:resolve-graphql"
     }
   ],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -81,7 +81,10 @@ export class Rewriter extends AppGraphQLClient {
 
   public async saveInternal(internal: InternalInput) {
     const { tenant } = this.context
-    return this.graphql.mutate<boolean, { route: InternalInput }>(
+    return this.graphql.mutate<
+      { internal: { type: string } },
+      { route: InternalInput }
+    >(
       {
         mutate: rewriterSaveInternalMutation,
         variables: { route: internal },
@@ -154,7 +157,7 @@ export class Rewriter extends AppGraphQLClient {
 
   public async deleteInternal(locator: RouteLocator) {
     return this.graphql.mutate<
-      boolean,
+      { internal: { id: string } },
       { path: string; locator: RouteLocator }
     >(
       {

--- a/node/middlewares/internals/brand.ts
+++ b/node/middlewares/internals/brand.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/internals'
 import { createTranslator } from '../../utils/messages'
 import { slugify } from '../../utils/slugify'
+import { deleteOldTranslation } from './delete'
 
 type Params = Record<string, string | undefined> | null | undefined
 
@@ -18,7 +19,7 @@ const pathFromRoute = (formatRoute: (x: Params) => string, brand: string) =>
 
 export async function brandInternals(ctx: Context, next: () => Promise<void>) {
   const {
-    clients: { apps, messages: messagesClient },
+    clients: { apps, messages: messagesClient, rewriter },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -47,6 +48,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
         messages
       )
       const path = pathFromRoute(formatRoute, translated)
+      await deleteOldTranslation(id, 'brand', bindingId, rewriter)
 
       return {
         binding: bindingId,

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/internals'
 import { createTranslator } from '../../utils/messages'
 import { slugify } from '../../utils/slugify'
+import { deleteOldTranslation } from './delete'
 
 type CategoryTypes = 'DEPARTMENT' | 'CATEGORY' | 'SUBCATEGORY'
 
@@ -59,7 +60,7 @@ export async function categoryInternals(
   next: () => Promise<void>
 ) {
   const {
-    clients: { apps, messages: messagesClient },
+    clients: { apps, messages: messagesClient, rewriter },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -97,6 +98,7 @@ export async function categoryInternals(
         messages
       )
       const path = pathFromTree(formatRoute, translatedTree)
+      await deleteOldTranslation(id, pageType, bindingId, rewriter)
 
       return {
         binding: bindingId,

--- a/node/middlewares/internals/delete.ts
+++ b/node/middlewares/internals/delete.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+import { LINKED } from '@vtex/api'
+
+import { Rewriter } from '../../clients/rewriter'
+
+export const deleteOldTranslation = async (
+  id: string,
+  type: string,
+  bindingId: string,
+  rewriter: Rewriter
+) => {
+  const routesById = await rewriter.routesById({ id, type })
+  const oldPath = routesById.find(({ binding }) => binding === bindingId)
+
+  if (!oldPath) {
+    return
+  }
+  if (LINKED) {
+    console.log('Deleted', { from: oldPath.route, binding: bindingId })
+  }
+  await rewriter.deleteInternal({ from: oldPath.route, binding: bindingId })
+}

--- a/node/middlewares/internals/delete.ts
+++ b/node/middlewares/internals/delete.ts
@@ -15,8 +15,9 @@ export const deleteOldTranslation = async (
   if (!oldPath) {
     return
   }
+  await rewriter.deleteInternal({ from: oldPath.route, binding: bindingId })
+
   if (LINKED) {
     console.log('Deleted', { from: oldPath.route, binding: bindingId })
   }
-  await rewriter.deleteInternal({ from: oldPath.route, binding: bindingId })
 }

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/internals'
 import { createTranslator } from '../../utils/messages'
 import { slugify } from '../../utils/slugify'
+import { deleteOldTranslation } from './delete'
 
 type Params = Record<string, string | undefined> | null | undefined
 
@@ -21,7 +22,7 @@ export async function productInternals(
   next: () => Promise<void>
 ) {
   const {
-    clients: { apps, messages: messagesClient },
+    clients: { apps, messages: messagesClient, rewriter },
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
@@ -53,6 +54,7 @@ export async function productInternals(
         messages
       )
       const path = pathFromRoute(formatRoute, translated)
+      await deleteOldTranslation(id, 'product', bindingId, rewriter)
 
       return {
         binding: bindingId,

--- a/node/package.json
+++ b/node/package.json
@@ -10,16 +10,16 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.30.1",
+    "@vtex/api": "6.31.1",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.8.3",
-    "vtex.catalog-api-proxy": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react",
-    "vtex.catalog-graphql": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-graphql@1.68.0/public/@types/vtex.catalog-graphql",
-    "vtex.messages": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.messages@1.59.2/public/@types/vtex.messages",
-    "vtex.rewriter": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.rewriter@1.35.1/public/@types/vtex.rewriter",
-    "vtex.search-graphql": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.search-graphql@0.21.1/public/@types/vtex.search-graphql",
-    "vtex.store-indexer": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-indexer@0.9.4/public/_types/react"
+    "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react",
+    "vtex.catalog-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.79.2/public/@types/vtex.catalog-graphql",
+    "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages",
+    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.45.2/public/@types/vtex.rewriter",
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.2/public/_types/react",
+    "vtex.store-indexer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-indexer@0.15.2/public/_types/react"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && tslint -c tslint.json --fix './**/*.ts'"

--- a/node/utils/slugify.ts
+++ b/node/utils/slugify.ts
@@ -4,5 +4,6 @@ export const slugify = (str: string) =>
   str
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[*+~.()'"!:@&\[\]`,/ %$#?{}|><=_^]/g, '-')
+    .replace(/([\u0300-\u036f])/g, '')
+    .replace(/([\u0020\u00A0])/g, '-')
+    .replace(/(\u00A0|[*+~.()'"!:@&\[\]`,/ %$#?{}|><=_^])/g, '-')

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1588,7 +1588,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.30.1":
-  version "6.30.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.1.tgz#e71ebed6cff6bfdec928535133ffe6d0522797ae"
-  integrity sha512-HfE5Jxii3daU8s3B0FS/5fKeoObkqZkdGBSz8iwWvhYN+nCrvJWm7J0KT5MyGNphp0E3ShxoHQhF46RUG8yXVA==
+"@vtex/api@6.31.1":
+  version "6.31.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.31.1.tgz#dcb7bddb0b77d6a1ad936da0a6bbc42d577b7883"
+  integrity sha512-KogyA3ZL4behY/8HG7SormxbcOnETJAre6sWkUvSbl1SYLoeL/znvMigzp5812lGDxqjwcIxW6AdFP2Qla+8zw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1844,29 +1844,29 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-"vtex.catalog-api-proxy@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react":
+"vtex.catalog-api-proxy@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.9.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.catalog-graphql@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-graphql@1.68.0/public/@types/vtex.catalog-graphql":
-  version "1.68.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-graphql@1.68.0/public/@types/vtex.catalog-graphql#7ac52cb196791ac824beeec892f9a5d744d60dd6"
+"vtex.catalog-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.79.2/public/@types/vtex.catalog-graphql":
+  version "1.79.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.79.2/public/@types/vtex.catalog-graphql#11592e444bd3d3ba42d712589472d9fd8303d0b6"
 
-"vtex.messages@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.messages@1.59.2/public/@types/vtex.messages":
-  version "1.59.2"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.messages@1.59.2/public/@types/vtex.messages#63cf1bc42e926b8d0eccb8a24b1e10f35c17dabf"
+"vtex.messages@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages":
+  version "1.60.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages#e9b6005f11925e99ac3bb56d47d3ea6ad6d18280"
 
-"vtex.rewriter@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.rewriter@1.35.1/public/@types/vtex.rewriter":
-  version "1.35.1"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.rewriter@1.35.1/public/@types/vtex.rewriter#32477e0ca215c999525dfcd72cbc57ce372613bf"
+"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.45.2/public/@types/vtex.rewriter":
+  version "1.45.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.45.2/public/@types/vtex.rewriter#1dc0d87a3a5d0c5948dc7f83886fc55841be0891"
 
-"vtex.search-graphql@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.search-graphql@0.21.1/public/@types/vtex.search-graphql":
-  version "0.21.1"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.search-graphql@0.21.1/public/@types/vtex.search-graphql#6b708e0948485dc252645451c83383b1a7631705"
-
-"vtex.store-indexer@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-indexer@0.9.4/public/_types/react":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.2/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-indexer@0.9.4/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.store-indexer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-indexer@0.15.2/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-indexer@0.15.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
**What problem is this solving?**
Currently when something is being indexed, we just create de internal and save it in rewriter. Meaning it can leave old routes, for example:
 If the name of a product from A to B, the internal with A as its route would be kept in rewriter instead.

**How should this be manually tested?**

You can test it by changing the name of a product or changing its translation in another binding's default language.

**Screenshots or example usage:**