### PR TITLE
Adds behavior for multi-language search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Setting to enable correct behavior for the multi-language search
 
 ## [0.16.2] - 2020-12-03
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,12 @@
         "type": "number",
         "default": 0,
         "description": "Store index will take this number of URLs, the most accessed ones based on access stats, make canonicals and index them at our sitemap."
+      },
+      "usesMultiLanguageSearch": {
+        "title": "Uses a Search that supports multi-language",
+        "type": "boolean",
+        "default": false,
+        "description": "Uses a Search that supports multi-language and can receive the search parameters in other languages"
       }
     }
   },
@@ -73,8 +79,6 @@
       "name": "vtex.rewriter:resolve-graphql"
     }
   ],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -61,9 +61,27 @@ const clients: ClientsConfig<Clients> = {
 export default new Service<Clients, State, ParamsContext>({
   clients,
   events: {
-    broadcasterBrand: [throttle, tenant, brandInternals, saveInternals],
-    broadcasterCategory: [throttle, tenant, categoryInternals, saveInternals],
-    broadcasterProduct: [throttle, tenant, productInternals, saveInternals],
+    broadcasterBrand: [
+      throttle,
+      settings,
+      tenant,
+      brandInternals,
+      saveInternals,
+    ],
+    broadcasterCategory: [
+      throttle,
+      settings,
+      tenant,
+      categoryInternals,
+      saveInternals,
+    ],
+    broadcasterProduct: [
+      throttle,
+      settings,
+      tenant,
+      productInternals,
+      saveInternals,
+    ],
     searchUrlsCountIndex: [
       throttle,
       settings,

--- a/node/middlewares/internals/brand.ts
+++ b/node/middlewares/internals/brand.ts
@@ -23,6 +23,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
+      settings: { usesMultiLanguageSearch },
     },
   } = ctx
   const brand: Brand = ctx.body
@@ -57,7 +58,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
         id,
         origin: INDEXED_ORIGIN,
         query: active ? { map: 'b' } : null,
-        resolveAs: tenantPath,
+        resolveAs: usesMultiLanguageSearch ? null : tenantPath,
         type: active ? PAGE_TYPES.BRAND : PAGE_TYPES.SEARCH_NOT_FOUND,
       }
     })

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -64,6 +64,7 @@ export async function categoryInternals(
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
+      settings: { usesMultiLanguageSearch },
     },
   } = ctx
   const category: IdentifiedCategory = ctx.body
@@ -107,7 +108,7 @@ export async function categoryInternals(
         id,
         origin: INDEXED_ORIGIN,
         query: isActive ? { map } : null,
-        resolveAs: tenantPath,
+        resolveAs: usesMultiLanguageSearch ? null : tenantPath,
         type: isActive ? pageType : PAGE_TYPES.SEARCH_NOT_FOUND,
       }
     })

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -26,6 +26,7 @@ export async function productInternals(
     state: {
       tenantInfo: { defaultLocale: tenantLocale },
       tenantInfo,
+      settings: { usesMultiLanguageSearch },
     },
   } = ctx
   const product: Product = ctx.body
@@ -62,7 +63,7 @@ export async function productInternals(
         from: path,
         id,
         origin: INDEXED_ORIGIN,
-        resolveAs: tenantPath,
+        resolveAs: usesMultiLanguageSearch ? null : tenantPath,
         type: isActive ? PAGE_TYPES.PRODUCT : PAGE_TYPES.PRODUCT_NOT_FOUND,
       }
     })

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -4,10 +4,12 @@ import { Context } from '../typings/global'
 
 export interface Settings {
   numberOfIndexedSearches: number
+  usesMultiLanguageSearch: boolean
 }
 
 export const DEFAULT_SETTINGS: Settings = {
   numberOfIndexedSearches: 0,
+  usesMultiLanguageSearch: false,
 }
 
 export async function settings(ctx: Context, next: () => Promise<void>) {

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.37.1",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.37.1":
+  version "6.37.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
+  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

With the multi-language search solution, the `resolveAs` attribute of the internal routes is no longer necessary. 
Currently, translated routes have it set with the original, not translated, route, so that the search parameters are sent not translated. However with the multi-language search the search parameters should be sent translated, so this PR adds a setting to save the routes without the `resolveAs` attribute

**How should this be manually tested?**

**Screenshots or example usage:**