### PR TITLE
Fix/improve route handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handles route translation errors
+- Deletes old routes after new routes are saved
 
 ## [0.16.4] - 2021-02-10
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "store-indexer",
   "vendor": "vtex",
-  "version": "0.16.4",
+  "version": "0.16.4-beta.0",
   "title": "Store Indexer",
   "description": "Listens to  IO-broadcaster for catalog itens changes.",
   "mustUpdateAt": "2020-07-29",
@@ -79,8 +79,6 @@
       "name": "vtex.rewriter:resolve-graphql"
     }
   ],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -9,6 +9,7 @@ import {
 import { Clients } from './clients'
 import { brandInternals } from './middlewares/internals/brand'
 import { categoryInternals } from './middlewares/internals/category'
+import { deleteOldRoutes } from './middlewares/internals/delete'
 import { productInternals } from './middlewares/internals/product'
 import { saveInternals } from './middlewares/internals/save'
 import { createCanonicals } from './middlewares/search/createCanonicals'
@@ -67,6 +68,7 @@ export default new Service<Clients, State, ParamsContext>({
       tenant,
       brandInternals,
       saveInternals,
+      deleteOldRoutes,
     ],
     broadcasterCategory: [
       throttle,
@@ -74,6 +76,7 @@ export default new Service<Clients, State, ParamsContext>({
       tenant,
       categoryInternals,
       saveInternals,
+      deleteOldRoutes,
     ],
     broadcasterProduct: [
       throttle,
@@ -81,6 +84,7 @@ export default new Service<Clients, State, ParamsContext>({
       tenant,
       productInternals,
       saveInternals,
+      deleteOldRoutes,
     ],
     searchUrlsCountIndex: [
       throttle,

--- a/node/middlewares/internals/brand.ts
+++ b/node/middlewares/internals/brand.ts
@@ -56,6 +56,7 @@ export async function brandInternals(ctx: Context, next: () => Promise<void>) {
           id,
           'brand',
           bindingId,
+          path,
           rewriter
         )
 

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -108,6 +108,7 @@ export async function categoryInternals(
           id,
           pageType,
           bindingId,
+          path,
           rewriter
         )
         const internal: InternalInput = {

--- a/node/middlewares/internals/category.ts
+++ b/node/middlewares/internals/category.ts
@@ -114,7 +114,12 @@ export async function categoryInternals(
           type: isActive ? pageType : PAGE_TYPES.SEARCH_NOT_FOUND,
         } as InternalInput
       } catch (error) {
-        logger.error({ message: 'Error creating internal', error })
+        logger.error({
+          binding: binding.id,
+          category,
+          error,
+          message: 'Error creating category internals',
+        })
         return null
       }
     })

--- a/node/middlewares/internals/delete.ts
+++ b/node/middlewares/internals/delete.ts
@@ -1,23 +1,24 @@
 /* eslint-disable no-console */
 import { LINKED } from '@vtex/api'
 
-import { Rewriter } from '../../clients/rewriter'
+import { Context } from '../../typings/global'
 
-export const deleteOldTranslation = async (
-  id: string,
-  type: string,
-  bindingId: string,
-  rewriter: Rewriter
-) => {
-  const routesById = await rewriter.routesById({ id, type })
-  const oldPath = routesById.find(({ binding }) => binding === bindingId)
-
-  if (!oldPath) {
-    return
+export async function deleteOldRoutes(ctx: Context, next: () => Promise<void>) {
+  const {
+    clients: { rewriter },
+    state: { oldRoutes },
+  } = ctx
+  if (oldRoutes) {
+    if (LINKED) {
+      console.log(
+        JSON.stringify({
+          message: 'Old Routes deletion',
+          oldRoutes,
+        })
+      )
+    }
+    await rewriter.deleteManyInternals(oldRoutes)
   }
-  await rewriter.deleteInternal({ from: oldPath.route, binding: bindingId })
 
-  if (LINKED) {
-    console.log('Deleted', { from: oldPath.route, binding: bindingId })
-  }
+  await next()
 }

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -63,6 +63,7 @@ export async function productInternals(
           id,
           'product',
           bindingId,
+          path,
           rewriter
         )
 

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -3,15 +3,16 @@ import { InternalInput } from 'vtex.rewriter'
 
 import { Context } from '../../typings/global'
 import { filterBindingsBySalesChannel } from '../../utils/bindings'
+import { deleteOldTranslation } from '../../utils/delete'
 import {
   INDEXED_ORIGIN,
   PAGE_TYPES,
+  processInternalAndOldRoute,
   routeFormatter,
   STORE_LOCATOR,
 } from '../../utils/internals'
 import { createTranslator } from '../../utils/messages'
 import { slugify } from '../../utils/slugify'
-import { deleteOldTranslation } from './delete'
 
 type Params = Record<string, string | undefined> | null | undefined
 
@@ -48,7 +49,7 @@ export async function productInternals(
 
   const tenantPath = pathFromRoute(formatRoute, linkId)
 
-  const internals = await Promise.all(
+  const internalsAndOldRoutes = await Promise.all(
     bindings.map(async binding => {
       try {
         const { defaultLocale: bindingLocale, id: bindingId } = binding
@@ -58,9 +59,14 @@ export async function productInternals(
           messages
         )
         const path = pathFromRoute(formatRoute, translated)
-        await deleteOldTranslation(id, 'product', bindingId, rewriter)
+        const oldRoute = await deleteOldTranslation(
+          id,
+          'product',
+          bindingId,
+          rewriter
+        )
 
-        return {
+        const internal: InternalInput = {
           binding: bindingId,
           declarer: STORE_LOCATOR,
           from: path,
@@ -68,7 +74,11 @@ export async function productInternals(
           origin: INDEXED_ORIGIN,
           resolveAs: usesMultiLanguageSearch ? null : tenantPath,
           type: isActive ? PAGE_TYPES.PRODUCT : PAGE_TYPES.PRODUCT_NOT_FOUND,
-        } as InternalInput
+        }
+        return {
+          internal,
+          oldRoute,
+        }
       } catch (error) {
         logger.error({
           binding: binding.id,
@@ -81,9 +91,12 @@ export async function productInternals(
     })
   )
 
-  ctx.state.internals = internals.filter(
-    internal => internal != null
-  ) as InternalInput[]
+  const { internals, oldRoutes } = processInternalAndOldRoute(
+    internalsAndOldRoutes
+  )
+
+  ctx.state.internals = internals
+  ctx.state.oldRoutes = oldRoutes
 
   await next()
 }

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.39.0",
+    "@vtex/api": "6.39.1",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",

--- a/node/typings/global.ts
+++ b/node/typings/global.ts
@@ -1,5 +1,5 @@
 import { EventContext, RecorderState, Tenant } from '@vtex/api'
-import { InternalInput } from 'vtex.rewriter'
+import { InternalInput, RouteLocator } from 'vtex.rewriter'
 
 import { Clients } from '../clients'
 import { Settings } from '../middlewares/settings'
@@ -11,6 +11,7 @@ export interface State extends RecorderState {
   settings: Settings
   tenantInfo: Tenant
   internals?: InternalInput[]
+  oldRoutes?: RouteLocator[]
 }
 
 export interface Event {

--- a/node/utils/delete.ts
+++ b/node/utils/delete.ts
@@ -6,12 +6,13 @@ export const deleteOldTranslation = async (
   id: string,
   type: string,
   bindingId: string,
+  newPath: string,
   rewriter: Rewriter
 ): Promise<RouteLocator | null> => {
   const routesById = await rewriter.routesById({ id, type })
   const oldPath = routesById.find(({ binding }) => binding === bindingId)
 
-  if (!oldPath) {
+  if (!oldPath || oldPath.route === newPath) {
     return null
   }
   return { from: oldPath.route, binding: bindingId }

--- a/node/utils/delete.ts
+++ b/node/utils/delete.ts
@@ -1,0 +1,18 @@
+import { RouteLocator } from 'vtex.rewriter'
+
+import { Rewriter } from '../clients/rewriter'
+
+export const deleteOldTranslation = async (
+  id: string,
+  type: string,
+  bindingId: string,
+  rewriter: Rewriter
+): Promise<RouteLocator | null> => {
+  const routesById = await rewriter.routesById({ id, type })
+  const oldPath = routesById.find(({ binding }) => binding === bindingId)
+
+  if (!oldPath) {
+    return null
+  }
+  return { from: oldPath.route, binding: bindingId }
+}

--- a/node/utils/internals.ts
+++ b/node/utils/internals.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-useless-escape */
 import { Apps } from '@vtex/api'
 import RouteParser from 'route-parser'
+import { InternalInput, RouteLocator } from 'vtex.rewriter'
 
 export const INDEXED_ORIGIN = `${process.env.VTEX_APP_ID!}:routes-indexing`
 export const STORE_LOCATOR = 'vtex.store@2.x'
@@ -32,6 +33,11 @@ export interface ContentTypeDefinition {
   canonical: string
 }
 
+export interface InternalAndOldRoute {
+  internal: InternalInput
+  oldRoute: RouteLocator | null
+}
+
 export type Routes = Record<string, ContentTypeDefinition>
 
 type PageTypes = typeof PAGE_TYPES[keyof typeof PAGE_TYPES]
@@ -52,4 +58,23 @@ export const routeFormatter = async (apps: Apps, type: PageTypes) => {
     }
     return path
   }
+}
+
+export const processInternalAndOldRoute = (
+  internalsAndOldRoutes: Array<InternalAndOldRoute | null>
+) => {
+  return internalsAndOldRoutes.reduce(
+    (acc, data) => {
+      if (data === null) {
+        return acc
+      }
+      const { internal, oldRoute } = data
+      acc.internals.push(internal)
+      if (oldRoute) {
+        acc.oldRoutes.push(oldRoute)
+      }
+      return acc
+    },
+    { internals: [] as InternalInput[], oldRoutes: [] as RouteLocator[] }
+  )
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1293,7 +1293,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.39.0":
-  version "6.39.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
-  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
+"@vtex/api@6.39.1":
+  version "6.39.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
+  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

1. Handles route translation errors 
     Currently if a route translation for a single language is the empty string all the other translated routes will not be saved. 
      This PR handles better these cases.
2. Deletes old routes after new routes are saved
      Currently old routes are deleted before the new ones are saved, so if any error happens before the routes are saved (like the one above) the old routes will stop working. This PR changes the structure to group all routes to be deleted and deletes them after the new routes are saved.

**How should this be manually tested?**

**Screenshots or example usage:**