### PR TITLE
Added/auttoken rewriter permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- CMS settings permission is now required when running `rewriter` queries
+- Authentication is now required when running `rewriter` queries
 
 ## [0.17.1] - 2024-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CMS settings permission is now required when running `rewriter` queries
+
 ## [0.17.0] - 2024-09-03
 ### Added
 - `resolveBrandMapQueryAs` in settings and `brandInternals`

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -78,7 +78,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-many-internal',
@@ -100,7 +100,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-internal',
@@ -176,8 +176,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie:
-            this.context.adminUserAuthToken ?? this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
         },
         metric: 'rewriter-delete-internal',
       }
@@ -199,7 +198,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-delete-many-internal',

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -78,6 +78,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-many-internal',
@@ -99,6 +100,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-internal',
@@ -191,6 +193,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-delete-many-internal',

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -78,7 +78,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-many-internal',
@@ -100,7 +100,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-save-internal',
@@ -173,6 +173,13 @@ export class Rewriter extends AppGraphQLClient {
         variables: { path: locator.from, locator },
       },
       {
+        headers: {
+          ...(this.options && this.options.headers),
+          'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie:
+            this.context.adminUserAuthToken ?? this.context.authToken,
+        },
+      {
         metric: 'rewriter-delete-internal',
       }
     )
@@ -193,7 +200,7 @@ export class Rewriter extends AppGraphQLClient {
         headers: {
           ...(this.options && this.options.headers),
           'Proxy-Authorization': this.context.authToken,
-          VtexIdclientAutCookie: this.context.adminUserAuthToken,
+          VtexIdclientAutCookie: this.context.adminUserAuthToken ?? this.context.authToken,
           'x-vtex-tenant': tenant,
         },
         metric: 'rewriter-delete-many-internal',

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -179,7 +179,6 @@ export class Rewriter extends AppGraphQLClient {
           VtexIdclientAutCookie:
             this.context.adminUserAuthToken ?? this.context.authToken,
         },
-      {
         metric: 'rewriter-delete-internal',
       }
     )

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -33,7 +33,7 @@ export async function productInternals(
     vtex: { logger },
   } = ctx
   const product: Product = ctx.body
-  const { linkId, isActive, id } = product
+  const { linkId, id } = product
   const bindings = filterBindingsBySalesChannel(
     tenantInfo,
     product.salesChannel
@@ -74,8 +74,9 @@ export async function productInternals(
           id,
           origin: INDEXED_ORIGIN,
           resolveAs: usesMultiLanguageSearch ? null : tenantPath,
-          type: isActive ? PAGE_TYPES.PRODUCT : PAGE_TYPES.PRODUCT_NOT_FOUND,
+          type: PAGE_TYPES.PRODUCT,
         }
+
         return {
           internal,
           oldRoute,

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -33,7 +33,7 @@ export async function productInternals(
     vtex: { logger },
   } = ctx
   const product: Product = ctx.body
-  const { linkId, id } = product
+  const { linkId, isActive, id } = product
   const bindings = filterBindingsBySalesChannel(
     tenantInfo,
     product.salesChannel
@@ -74,7 +74,7 @@ export async function productInternals(
           id,
           origin: INDEXED_ORIGIN,
           resolveAs: usesMultiLanguageSearch ? null : tenantPath,
-          type: PAGE_TYPES.PRODUCT,
+          type: isActive ? PAGE_TYPES.PRODUCT : PAGE_TYPES.PRODUCT_NOT_FOUND,
         }
 
         return {

--- a/node/middlewares/internals/product.ts
+++ b/node/middlewares/internals/product.ts
@@ -76,7 +76,6 @@ export async function productInternals(
           resolveAs: usesMultiLanguageSearch ? null : tenantPath,
           type: isActive ? PAGE_TYPES.PRODUCT : PAGE_TYPES.PRODUCT_NOT_FOUND,
         }
-
         return {
           internal,
           oldRoute,

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.38",
     "@types/route-parser": "^0.1.3",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "tslint": "^5.14.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -148,10 +148,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1318,7 +1318,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
This PR blocks requests to the redirect mutations when the user is not authenticated. This is a security fix due to a report made by a client. With that, only users authenticated will be able to do that

[Workspace to test](https://storecomponents.myvtex.com/admin/catalog-translation/category)

How to test it: 

Try to change link id from a category, brand or product at admin/catalog-translation

If you want to test it into your account, there's a beta version for the store-indexer:

```
vtex.store-indexer@0.18.0-beta.1
```

<img width="753" alt="image" src="https://github.com/user-attachments/assets/e1c4aaa2-1d77-46b7-8b90-844bab1540d6" />

Its related to [this rewriter fix](https://github.com/vtex/rewriter/pull/233) released and this [update](https://github.com/vtex/rewriter/pull/238)